### PR TITLE
Make getDisplaySaturation() return 0-400

### DIFF
--- a/src/displaymanager.cpp
+++ b/src/displaymanager.cpp
@@ -32,7 +32,7 @@ QStringList displayManager::getDisplayNames(){
 }
 
 int displayManager::getDisplaySaturation(const QString& name){
-	return vibrant_controller_get_saturation(controllers[name].v_controller);
+	return vibrant_controller_get_saturation(controllers[name].v_controller) * 100;
 }
 
 void displayManager::updateSaturation(QListWidget* watchlist){


### PR DESCRIPTION
This function internally calls `vibrant_controller_get_saturation()` -- from [libvibrant](https://gitlab.com/Scrumplex/vibrant/-/blob/1.0.1/vibrant/include/vibrant/vibrant.h#L114-120), which only returns a value between 0.0 and 4.0.

In order for us to use that value on the slider (which ranges from 0 to 400), first we have to multiply it by 100.

Fixes #16.